### PR TITLE
dataProviderをGeneratorで書き直す

### DIFF
--- a/tests/ClassManipulator/ClassLikeWrapperTest.php
+++ b/tests/ClassManipulator/ClassLikeWrapperTest.php
@@ -34,9 +34,8 @@ final class ClassLikeWrapperTest extends TestCase
 
     /**
      * @noinspection NonAsciiCharacters
-     * @return array<string, array<int, Class_|string>>
      */
-    public function dataクラスの名前が取得できること(): array
+    public function dataクラスの名前が取得できること(): \Generator
     {
         $class1 = new Class_(new Identifier('Bar'));
         $class1->namespacedName = new FullyQualified('Foo\Bar');
@@ -44,19 +43,17 @@ final class ClassLikeWrapperTest extends TestCase
         $class2->namespacedName = null;
         $class3 =  new Class_(new Identifier('Bar'));
         $class3->namespacedName = null;
-        return [
-            '完全修飾名が取得できること' => [
-                $class1,
-                '\Foo\Bar',
-            ],
-            '名前が空であること' => [
-                $class2,
-                '',
-            ],
-            '完全修飾名ではない名前が取得できること' => [
-               $class3,
-                'Bar',
-            ],
+        yield '完全修飾名が取得できること' => [
+            $class1,
+            '\Foo\Bar',
+        ];
+        yield '名前が空であること' => [
+            $class2,
+            '',
+        ];
+        yield '完全修飾名ではない名前が取得できること' => [
+            $class3,
+            'Bar',
         ];
     }
 
@@ -78,31 +75,28 @@ final class ClassLikeWrapperTest extends TestCase
 
     /**
      * @noinspection NonAsciiCharacters
-     * @return array<string, array<int, ClassLike|string>>
      */
-    public function data宣言する要素が取得できること(): array
+    public function data宣言する要素が取得できること(): \Generator
     {
-        return [
-            '具象クラス' => [
-                new Class_(''),
-                'class',
-            ],
-            '抽象クラス' => [
-                new Class_('', ['flags' => Modifiers::ABSTRACT]),
-                'abstract',
-            ],
-            'インタフェース' => [
-                new Interface_(''),
-                'interface',
-            ],
-            'トレイト' => [
-                new Trait_(''),
-                'trait',
-            ],
-            'enum' => [
-                new Enum_(''),
-                'enum',
-            ],
+        yield '具象クラス' => [
+            new Class_(''),
+            'class',
+        ];
+        yield '抽象クラス' => [
+            new Class_('', ['flags' => Modifiers::ABSTRACT]),
+            'abstract',
+        ];
+        yield 'インタフェース' => [
+            new Interface_(''),
+            'interface',
+        ];
+        yield 'トレイト' => [
+            new Trait_(''),
+            'trait',
+        ];
+        yield 'enum' => [
+            new Enum_(''),
+            'enum',
         ];
     }
 

--- a/tests/ClassManipulator/ClassLoaderTest.php
+++ b/tests/ClassManipulator/ClassLoaderTest.php
@@ -33,9 +33,8 @@ final class ClassLoaderTest extends TestCase
 
     /**
      * @noinspection NonAsciiCharacters
-     * @return array<string, array<int, string|FullyQualified>>
      */
-    public function data対象に応じてロードできること(): array
+    public function data対象に応じてロードできること(): \Generator
     {
         $userDefinedClassCode = <<<CODE
 <?php
@@ -43,27 +42,25 @@ namespace Hirokinoue\DependencyVisualizer\Tests\data;
 class UserDefinedClass{}
 
 CODE;
-        return [
-            'ユーザー定義クラスはクラス名とコードが取得できる' => [
-                new FullyQualified('Hirokinoue\DependencyVisualizer\Tests\data\UserDefinedClass'),
-                '\Hirokinoue\DependencyVisualizer\Tests\data\UserDefinedClass',
-                $userDefinedClassCode,
-            ],
-            '内部クラスはクラス名のみ取得できる' => [
-                new FullyQualified('Exception'),
-                '\Exception',
-                '',
-            ],
-            '定数はクラス名もコードも取得できない' => [
-                new FullyQualified('FOO'),
-                '',
-                '',
-            ],
-            'キーワードはクラス名もコードも取得できない' => [
-                new FullyQualified('true'),
-                '',
-                '',
-            ],
+        yield 'ユーザー定義クラスはクラス名とコードが取得できる' => [
+            new FullyQualified('Hirokinoue\DependencyVisualizer\Tests\data\UserDefinedClass'),
+            '\Hirokinoue\DependencyVisualizer\Tests\data\UserDefinedClass',
+            $userDefinedClassCode,
+        ];
+        yield '内部クラスはクラス名のみ取得できる' => [
+            new FullyQualified('Exception'),
+            '\Exception',
+            '',
+        ];
+        yield '定数はクラス名もコードも取得できない' => [
+            new FullyQualified('FOO'),
+            '',
+            '',
+        ];
+        yield 'キーワードはクラス名もコードも取得できない' => [
+            new FullyQualified('true'),
+            '',
+            '',
         ];
     }
 
@@ -90,9 +87,8 @@ CODE;
 
     /**
      * @noinspection NonAsciiCharacters
-     * @return array<string, array<int, FullyQualified|string|bool>>
      */
-    public function dataロードしたことのあるクラスを再びロードしないこと(): array
+    public function dataロードしたことのあるクラスを再びロードしないこと(): \Generator
     {
         $userDefinedClass = 'Hirokinoue\DependencyVisualizer\Tests\data\UserDefinedClass';
         $userDefinedClassCode = <<<CODE
@@ -101,17 +97,15 @@ namespace Hirokinoue\DependencyVisualizer\Tests\data;
 class UserDefinedClass{}
 
 CODE;
-        return [
-            '初回はロードする' => [
-                new FullyQualified($userDefinedClass),
-                '\\' . $userDefinedClass,
-                $userDefinedClassCode,
-            ],
-            '2回目以降はロードしない' => [
-                new FullyQualified($userDefinedClass),
-                '\\' . $userDefinedClass,
-                '',
-            ],
+        yield '初回はロードする' => [
+            new FullyQualified($userDefinedClass),
+            '\\' . $userDefinedClass,
+            $userDefinedClassCode,
+        ];
+        yield '2回目以降はロードしない' => [
+            new FullyQualified($userDefinedClass),
+            '\\' . $userDefinedClass,
+            '',
         ];
     }
 

--- a/tests/DependencyVisualizerTest.php
+++ b/tests/DependencyVisualizerTest.php
@@ -31,9 +31,8 @@ final class DependencyVisualizerTest extends TestCase
 
     /**
      * @noinspection NonAsciiCharacters
-     * @return array<string, array<int, string>>
      */
-    public function data分析結果をテキスト形式で出力できること(): array
+    public function data分析結果をテキスト形式で出力できること(): \Generator
     {
         $rootIsClass = <<<RESULT
 \Hirokinoue\DependencyVisualizer\Tests\data\Foo
@@ -64,23 +63,21 @@ RESULT;
   \Hirokinoue\DependencyVisualizer\Tests\data\RedundantDependency\C
 
 RESULT;
-        return [
-            '始点がクラスの時ルートがクラス名' => [
-                __DIR__ . '/data/Foo.php',
-                $rootIsClass,
-            ],
-            '始点がクラスではない時ルートがroot' => [
-                __DIR__ . '/data/foo.php',
-                $rootIsNotClass,
-            ],
-            '循環依存があっても無限ループせず解析が完了する' => [
-                __DIR__ . '/data/InfiniteLoop/A.php',
-                $infiniteLoop,
-            ],
-            '同じクラスを複数回使用する場合1つだけ図示する' => [
-                __DIR__ . '/data/RedundantDependency/A.php',
-                $performanceEnhancement,
-            ],
+        yield '始点がクラスの時ルートがクラス名' => [
+            __DIR__ . '/data/Foo.php',
+            $rootIsClass,
+        ];
+        yield '始点がクラスではない時ルートがroot' => [
+            __DIR__ . '/data/foo.php',
+            $rootIsNotClass,
+        ];
+        yield '循環依存があっても無限ループせず解析が完了する' => [
+            __DIR__ . '/data/InfiniteLoop/A.php',
+            $infiniteLoop,
+        ];
+        yield '同じクラスを複数回使用する場合1つだけ図示する' => [
+            __DIR__ . '/data/RedundantDependency/A.php',
+            $performanceEnhancement,
         ];
     }
 }

--- a/tests/DiagramUnitTest.php
+++ b/tests/DiagramUnitTest.php
@@ -106,17 +106,14 @@ final class DiagramUnitTest extends TestCase
 
     /**
      * @noinspection NonAsciiCharacters
-     * @return array<string, array<int, string>>
      */
-    public function data指定された名前空間のクラスをトラバースしないこと(): array
+    public function data指定された名前空間のクラスをトラバースしないこと(): \Generator
     {
-        return [
-            '名前空間を完全修飾名で指定する' => [
-                __DIR__ . '/data/DiagramUnit/Config/0',
-            ],
-            '名前空間を修飾名で指定する' => [
-                __DIR__ . '/data/DiagramUnit/Config/1',
-            ],
+        yield '名前空間を完全修飾名で指定する' => [
+            __DIR__ . '/data/DiagramUnit/Config/0',
+        ];
+        yield '名前空間を修飾名で指定する' => [
+            __DIR__ . '/data/DiagramUnit/Config/1',
         ];
     }
 
@@ -164,51 +161,48 @@ final class DiagramUnitTest extends TestCase
 
     /**
      * @noinspection NonAsciiCharacters
-     * @return array<string, array<int, DiagramUnit|bool>>
      */
-    public function data解析結果のルートを見分けられること(): array
+    public function data解析結果のルートを見分けられること(): \Generator
     {
-        return [
-            '解析結果がルートではない_クラスのファイルがない' => [
-                new DiagramUnit(
-                    '\Foo',
-                    ['\Foo'],
-                    false,
-                    null
-                ),
+        yield '解析結果がルートではない_クラスのファイルがない' => [
+            new DiagramUnit(
+                '\Foo',
+                ['\Foo'],
                 false,
+                null
+            ),
+            false,
+            false,
+        ];
+        yield '解析結果がルートではない_クラスのファイルがある' => [
+            new DiagramUnit(
+                '\Foo',
+                ['\Foo'],
                 false,
-            ],
-            '解析結果がルートではない_クラスのファイルがある' => [
-                new DiagramUnit(
-                    '\Foo',
-                    ['\Foo'],
-                    false,
-                    new ClassLikeWrapper(new Class_('Bar'))
-                ),
-                false,
-                false,
-            ],
-            '解析結果がルート_クラスのファイルがない' => [
-                new DiagramUnit(
-                    '\Foo',
-                    ['\Foo'],
-                    true,
-                    null
-                ),
-                false,
+                new ClassLikeWrapper(new Class_('Bar'))
+            ),
+            false,
+            false,
+        ];
+        yield '解析結果がルート_クラスのファイルがない' => [
+            new DiagramUnit(
+                '\Foo',
+                ['\Foo'],
                 true,
-            ],
-            '解析結果がルート_クラスのファイルがある' => [
-                new DiagramUnit(
-                    '\Foo',
-                    ['\Foo'],
-                    true,
-                    new ClassLikeWrapper(new Class_('Bar'))
-                ),
+                null
+            ),
+            false,
+            true,
+        ];
+        yield '解析結果がルート_クラスのファイルがある' => [
+            new DiagramUnit(
+                '\Foo',
+                ['\Foo'],
                 true,
-                false,
-            ],
+                new ClassLikeWrapper(new Class_('Bar'))
+            ),
+            true,
+            false,
         ];
     }
 
@@ -306,38 +300,35 @@ final class DiagramUnitTest extends TestCase
 
     /**
      * @noinspection NonAsciiCharacters
-     * @return array<string, array<int, DiagramUnit|bool>>
      */
-    public function dataトレイトを判定できること(): array
+    public function dataトレイトを判定できること(): \Generator
     {
-        return [
-            '具象クラス' => [
-                new DiagramUnit(
-                    '\Foo',
-                    ['\Foo'],
-                    false,
-                    new ClassLikeWrapper(new Class_('Bar'))
-                ),
+        yield '具象クラス' => [
+            new DiagramUnit(
+                '\Foo',
+                ['\Foo'],
                 false,
-            ],
-            'トレイト' => [
-                new DiagramUnit(
-                    '\Foo',
-                    ['\Foo'],
-                    false,
-                    new ClassLikeWrapper(new Trait_('Bar'))
-                ),
-                true,
-            ],
-            'クラス類ではない' => [
-                new DiagramUnit(
-                    '\Foo',
-                    ['\Foo'],
-                    false,
-                    null
-                ),
+                new ClassLikeWrapper(new Class_('Bar'))
+            ),
+            false,
+        ];
+        yield 'トレイト' => [
+            new DiagramUnit(
+                '\Foo',
+                ['\Foo'],
                 false,
-            ],
+                new ClassLikeWrapper(new Trait_('Bar'))
+            ),
+            true,
+        ];
+        yield 'クラス類ではない' => [
+            new DiagramUnit(
+                '\Foo',
+                ['\Foo'],
+                false,
+                null
+            ),
+            false,
         ];
     }
 

--- a/tests/Visitor/ClassVisitorTest.php
+++ b/tests/Visitor/ClassVisitorTest.php
@@ -2,14 +2,12 @@
 
 namespace Hirokinoue\DependencyVisualizer\Tests\Visitor;
 
-use _HumbugBox72e598a46208\RdKafka\Conf;
 use Hirokinoue\DependencyVisualizer\ClassManipulator\ClassLikeNodeFinder;
 use Hirokinoue\DependencyVisualizer\ClassManipulator\ClassLikeWrapper;
 use Hirokinoue\DependencyVisualizer\ClassManipulator\ClassLoader;
 use Hirokinoue\DependencyVisualizer\Config\Config;
 use Hirokinoue\DependencyVisualizer\DiagramUnit;
 use Hirokinoue\DependencyVisualizer\Exporter\StringExporter;
-use Hirokinoue\DependencyVisualizer\Logger;
 use Hirokinoue\DependencyVisualizer\Visitor\ClassVisitor;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name\FullyQualified;
@@ -122,17 +120,14 @@ RESULT;
 
     /**
      * @noinspection NonAsciiCharacters
-     * @return array<string, array<int, string>>
      */
-    public function data指定された名前空間を解析しないこと(): array
+    public function data指定された名前空間を解析しないこと(): \Generator
     {
-        return [
-            '名前空間を完全修飾名で指定する' => [
-                __DIR__ . '/../data/Visitor/Config/0',
-            ],
-            '名前空間を修飾名で指定する' => [
-                __DIR__ . '/../data/Visitor/Config/1',
-            ],
+        yield '名前空間を完全修飾名で指定する' => [
+            __DIR__ . '/../data/Visitor/Config/0',
+        ];
+        yield '名前空間を修飾名で指定する' => [
+            __DIR__ . '/../data/Visitor/Config/1',
         ];
     }
 


### PR DESCRIPTION
コミットログを参照のこと。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Updated multiple test methods to use `\Generator` for improved performance and memory efficiency.
	- Adopted `yield` statements for more efficient iteration in test cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->