### PR TITLE
解析するファイルを制限できるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Add a `config.php`, `config.php.dist` or `config.dist.php` to the directory from
 <?php declare(strict_types=1);
 return $config = [
     'memoryLimit' => '1024M',
+    'maxDepth' => 5,
     // Specify a part of a namespace to exclude classes from the analysis.
     // For example, when dependencies of third-party packages are not wanted to be analyzed.
     // Classes starting with the given namespace will not be analyzed and classes they depend on will not.
@@ -42,6 +43,9 @@ return $config = [
     // Classes starting with the given namespace will not be analyzed.
     'excludeFromAnalysis' => [
         'Foo\Bar\\',
+    // Specify the relative path from the directory where the application is executed.
+    'excludeFilePath' => [
+        '',
     ],
 ];
 ```

--- a/config.php
+++ b/config.php
@@ -1,6 +1,7 @@
 <?php declare(strict_types=1);
 return $config = [
     'memoryLimit' => '1024M',
+    'maxDepth' => 5,
     // Specify a part of a namespace to exclude classes from the analysis.
     // For example, when dependencies of third-party packages are not wanted to be analyzed.
     // Classes starting with the given namespace will not be analyzed and classes they depend on will not.
@@ -14,5 +15,8 @@ return $config = [
     'excludeFromAnalysis' => [
         'PhpParser\Node\\',
     ],
-    'maxDepth' => 5,
+    // Specify the relative path from the directory where the application is executed.
+    'excludeFilePath' => [
+        '',
+    ],
 ];

--- a/src/ClassManipulator/ClassLoader.php
+++ b/src/ClassManipulator/ClassLoader.php
@@ -2,6 +2,7 @@
 
 namespace Hirokinoue\DependencyVisualizer\ClassManipulator;
 
+use Hirokinoue\DependencyVisualizer\Config\Config;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt;
 use PhpParser\ParserFactory;
@@ -41,12 +42,24 @@ final class ClassLoader
         }
 
         $path = ($reflector->getFileName() === false) ? '' : $reflector->getFileName();
-        $code = self::readFile($path);
+        $code = self::isExcludedFile($path)
+            ? ''
+            : self::readFile($path);
 
         self::$loadedClasses[] = $fullyQualifiedName;
 
         // 定義済みクラスは$codeが空
         return new self($fullyQualifiedName, $code);
+    }
+
+    private static function isExcludedFile(string $absolutePath): bool
+    {
+        foreach (Config::excludeFilePath() as $excludeFilePath) {
+            if ($absolutePath === \getcwd()  . '/' . $excludeFilePath) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static function readFile(string $path): string {

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -5,11 +5,13 @@ namespace Hirokinoue\DependencyVisualizer\Config;
 class Config
 {
     private static string $memoryLimit = '1024M';
+    private static int $maxDepth = 5;
     /** @var string[] */
     private static array $endOfAnalysis = [];
     /** @var string[] */
     private static array $excludeFromAnalysis = [];
-    private static int $maxDepth = 5;
+    /** @var string[] */
+    private static array $excludeFilePath = [];
 
     public static function initialize(string $baseDir): void
     {
@@ -24,14 +26,20 @@ class Config
             }
         }
         self::$memoryLimit = $config['memoryLimit'] ?? '1024M';
+        self::$maxDepth = $config['maxDepth'] ?? 5;
         self::$endOfAnalysis = $config['endOfAnalysis'] ?? [];
         self::$excludeFromAnalysis = $config['excludeFromAnalysis'] ?? [];
-        self::$maxDepth = $config['maxDepth'] ?? 5;
+        self::$excludeFilePath = $config['excludeFilePath'] ?? [];
     }
 
     public static function memoryLimit(): string
     {
         return self::$memoryLimit;
+    }
+
+    public static function maxDepth(): int
+    {
+        return self::$maxDepth;
     }
 
     /**
@@ -50,8 +58,11 @@ class Config
         return self::$excludeFromAnalysis;
     }
 
-    public static function maxDepth(): int
+    /**
+     * @return string[]
+     */
+    public static function excludeFilePath(): array
     {
-        return self::$maxDepth;
+        return self::$excludeFilePath;
     }
 }

--- a/tests/Config/ConfigTest.php
+++ b/tests/Config/ConfigTest.php
@@ -17,11 +17,13 @@ final class ConfigTest extends TestCase
 
         // when
         $memoryLimit = Config::memoryLimit();
+        $maxDepth = Config::maxDepth();
         $endOfAnalysis = Config::endOfAnalysis();
         $excludeFromAnalysis = Config::excludeFromAnalysis();
 
         // then
         $this->assertSame('Foo', $memoryLimit);
+        $this->assertSame(5, $maxDepth);
         $this->assertSame(['Bar\\'], $endOfAnalysis);
         $this->assertSame(['Baz\\'], $excludeFromAnalysis);
     }

--- a/tests/Config/ConfigTest.php
+++ b/tests/Config/ConfigTest.php
@@ -20,11 +20,13 @@ final class ConfigTest extends TestCase
         $maxDepth = Config::maxDepth();
         $endOfAnalysis = Config::endOfAnalysis();
         $excludeFromAnalysis = Config::excludeFromAnalysis();
+        $excludeFilePath = Config::excludeFilePath();
 
         // then
         $this->assertSame('Foo', $memoryLimit);
         $this->assertSame(5, $maxDepth);
         $this->assertSame(['Bar\\'], $endOfAnalysis);
         $this->assertSame(['Baz\\'], $excludeFromAnalysis);
+        $this->assertSame(['src/Qux.php'], $excludeFilePath);
     }
 }

--- a/tests/data/ClassManipulator/Exclude/config.dist.php
+++ b/tests/data/ClassManipulator/Exclude/config.dist.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+return $config = [
+    'memoryLimit' => '1024M',
+    'maxDepth' => 5,
+    'endOfAnalysis' => [
+    ],
+    'excludeFromAnalysis' => [
+    ],
+    'excludeFilePath' => [
+        'tests/data/ClassManipulator/UserDefinedClass.php',
+    ],
+];

--- a/tests/data/ClassManipulator/NonExclude/config.dist.php
+++ b/tests/data/ClassManipulator/NonExclude/config.dist.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+return $config = [
+    'memoryLimit' => '1024M',
+    'maxDepth' => 5,
+    'endOfAnalysis' => [
+    ],
+    'excludeFromAnalysis' => [
+    ],
+    'excludeFilePath' => [
+    ],
+];

--- a/tests/data/ClassManipulator/UserDefinedClass.php
+++ b/tests/data/ClassManipulator/UserDefinedClass.php
@@ -1,0 +1,3 @@
+<?php
+namespace Hirokinoue\DependencyVisualizer\Tests\data\ClassManipulator;
+class UserDefinedClass{}

--- a/tests/data/Config/config.dist.php
+++ b/tests/data/Config/config.dist.php
@@ -1,6 +1,7 @@
 <?php declare(strict_types=1);
 return $config = [
     'memoryLimit' => 'Foo',
+    'maxDepth' => 5,
     'endOfAnalysis' => [
         'Bar\\',
     ],

--- a/tests/data/Config/config.dist.php
+++ b/tests/data/Config/config.dist.php
@@ -8,4 +8,7 @@ return $config = [
     'excludeFromAnalysis' => [
         'Baz\\',
     ],
+    'excludeFilePath' => [
+        'src/Qux.php',
+    ],
 ];

--- a/tests/data/UserDefinedClass.php
+++ b/tests/data/UserDefinedClass.php
@@ -1,3 +1,0 @@
-<?php
-namespace Hirokinoue\DependencyVisualizer\Tests\data;
-class UserDefinedClass{}


### PR DESCRIPTION
- 漏れていたテストを追加する。
- 指定したファイルを解析しないようにする。
- READMEにConfigの変更を反映する。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration parameter `maxDepth` to limit depth of operations.
	- Added the ability to exclude specific file paths from processing through `excludeFilePath` setting.
- **Refactor**
	- Split the `$maxDepth` property into separate properties for better clarity and functionality.
	- Enhanced file exclusion logic with the new `isExcludedFile` method.
- **Tests**
	- Expanded test coverage to include new configuration parameters and exclusion logic.
- **Documentation**
	- Updated README and configuration files to reflect new features and settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->